### PR TITLE
Hotfix EPL-1081: Move flags from RX gradle.properties to root

### DIFF
--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -11,3 +11,6 @@ githubUser=
 githubToken=
 nexusUser=
 nexusPassword=
+
+rx.computedColumns=true
+rx.views=true

--- a/src-rx/gradle.properties.template
+++ b/src-rx/gradle.properties.template
@@ -12,6 +12,3 @@ bbdd.sessionConfig=select update_dateFormat('DD-MM-YYYY')
 
 # Boolean value to generate or not code to RX
 rx.generateCode=true
-
-rx.computedColumns=true
-rx.views=true


### PR DESCRIPTION
The RX gradle.properties.template has two properties that were needed to be moved into the root gradle.properties.template